### PR TITLE
Docs: Correctly specified no. of training steps in Experiment 1

### DIFF
--- a/EXPERIMENT_1_RESULTS.md
+++ b/EXPERIMENT_1_RESULTS.md
@@ -2,7 +2,7 @@
 
 ## Configuration
 - **Model**: MoE Transformer (384d, 6L, 8H, 1536ff)
-- **Training**: 1000 steps, batch size 24, gradient accumulation 4
+- **Training**: 5000 steps, batch size 24, gradient accumulation 4
 - **Data**: 500K tokens from SmolLM corpus
 - **Optimizers**: Muon (hybrid) vs AdamW (pure)
 - **Random Seed**: 42

--- a/paper.tex
+++ b/paper.tex
@@ -64,7 +64,8 @@ All experiments were conducted using a consistent setup to ensure comparability 
 \begin{itemize}
     \item \textbf{Model Architecture}: A 6-layer MoE Transformer with a model dimension of 384, 8 attention heads, and a feed-forward dimension of 1536. The model included 8 experts, with a top-2 routing strategy.
     \item \textbf{Dataset}: A 500,000 token subset of the SmolLM corpus.
-    \item \textbf{Training}: All models were trained for 1000 steps with a batch size of 24 and 4 gradient accumulation steps.
+    \item \textbf{Training}: Models were trained with a batch size of 24 and 4 gradient accumulation steps. The baseline comparison (Experiment 1) was run for \textbf{5000 steps}, while the ablation and hyperparameter studies (Experiments 2 and 3) were run for \textbf{1000 steps} to facilitate quicker iteration.
+
     \item \textbf{Hardware}: Experiments were conducted in a low-compute environment, utilizing a single NVIDIA RTX 4090 GPU or a Google Colab T4 GPU. Future experiments may be upgraded to higher-compute environments.
 \end{itemize}
 

--- a/paper.tex
+++ b/paper.tex
@@ -65,7 +65,6 @@ All experiments were conducted using a consistent setup to ensure comparability 
     \item \textbf{Model Architecture}: A 6-layer MoE Transformer with a model dimension of 384, 8 attention heads, and a feed-forward dimension of 1536. The model included 8 experts, with a top-2 routing strategy.
     \item \textbf{Dataset}: A 500,000 token subset of the SmolLM corpus.
     \item \textbf{Training}: Models were trained with a batch size of 24 and 4 gradient accumulation steps. The baseline comparison (Experiment 1) was run for \textbf{5000 steps}, while the ablation and hyperparameter studies (Experiments 2 and 3) were run for \textbf{1000 steps} to facilitate quicker iteration.
-
     \item \textbf{Hardware}: Experiments were conducted in a low-compute environment, utilizing a single NVIDIA RTX 4090 GPU or a Google Colab T4 GPU. Future experiments may be upgraded to higher-compute environments.
 \end{itemize}
 


### PR DESCRIPTION
This fixes issue #1
Changes made in both the markdown summary and the paper.